### PR TITLE
update typing for authzyin react context

### DIFF
--- a/example/src/components/Home.tsx
+++ b/example/src/components/Home.tsx
@@ -9,6 +9,10 @@ import { AuthorizationData } from '../api/Contract';
 export const Home = () => {
     const context = useAuthZyinContext<AuthorizationData>();
 
+    if (!context) {
+        return <></>;
+    }
+
     return (
         <div>
             <Typography variant="h2" component="h2">

--- a/example/src/components/User.tsx
+++ b/example/src/components/User.tsx
@@ -12,24 +12,22 @@ export const User = () => {
 
     // main rendering based on state
     return (
-        <div>
-            <Card variant="outlined">
-                <CardHeader title='User information' />
-                <CardContent>
-                    <Typography variant="body1" component="div">
-                        Age: {context.data.age}
+        <Card variant="outlined">
+            <CardHeader title='User information' />
+            <CardContent>
+                <Typography variant="body1" component="div">
+                    Age: {context.data.age}
+                </Typography>
+                <Typography variant="body1" component="div">
+                    Has driver's license: {String(context.data.withDriversLicense)}
+                </Typography>
+                <Typography variant="body1" component="div">
+                    Has passport: {String(context.data.withPassport)}
                     </Typography>
-                    <Typography variant="body1" component="div">
-                        Has driver's license: {String(context.data.withDriversLicense)}
-                    </Typography>
-                    <Typography variant="body1" component="div">
-                        Has passport: {String(context.data.withPassport)}
-                        </Typography>
-                    <Typography variant="body1" component="div">
-                        PaymentMethods: {JSON.stringify(context.data.paymentMethods.map(x => x.type))}
-                    </Typography>
-                </CardContent>
-            </Card>
-        </div>
+                <Typography variant="body1" component="div">
+                    PaymentMethods: {JSON.stringify(context.data.paymentMethods.map(x => x.type))}
+                </Typography>
+            </CardContent>
+        </Card>
     );
 };

--- a/example/src/components/User.tsx
+++ b/example/src/components/User.tsx
@@ -4,32 +4,32 @@ import { useAuthZyinContext } from 'authzyin.js';
 import { AuthorizationData } from '../api/Contract';
 
 export const User = () => {
-    const clientContext = useAuthZyinContext<AuthorizationData>();
+    const context = useAuthZyinContext<AuthorizationData>();
 
-    // main rendering based on state
-    if (clientContext) {
-        return (
-            <div>
-                <Card variant="outlined">
-                    <CardHeader title='User information' />
-                    <CardContent>
-                        <Typography variant="body1" component="div">
-                            Age: {clientContext.data.age}
-                        </Typography>
-                        <Typography variant="body1" component="div">
-                            Has driver's license: {String(clientContext.data.withDriversLicense)}
-                        </Typography>
-                        <Typography variant="body1" component="div">
-                            Has passport: {String(clientContext.data.withPassport)}
-                            </Typography>
-                        <Typography variant="body1" component="div">
-                            PaymentMethods: {JSON.stringify(clientContext.data.paymentMethods.map(x => x.type))}
-                        </Typography>
-                    </CardContent>
-                </Card>
-            </div>
-        );
+    if (!context) {
+        return <></>;
     }
 
-    return <></>;
+    // main rendering based on state
+    return (
+        <div>
+            <Card variant="outlined">
+                <CardHeader title='User information' />
+                <CardContent>
+                    <Typography variant="body1" component="div">
+                        Age: {context.data.age}
+                    </Typography>
+                    <Typography variant="body1" component="div">
+                        Has driver's license: {String(context.data.withDriversLicense)}
+                    </Typography>
+                    <Typography variant="body1" component="div">
+                        Has passport: {String(context.data.withPassport)}
+                        </Typography>
+                    <Typography variant="body1" component="div">
+                        PaymentMethods: {JSON.stringify(context.data.paymentMethods.map(x => x.type))}
+                    </Typography>
+                </CardContent>
+            </Card>
+        </div>
+    );
 };

--- a/src/AuthZyinProvider.test.tsx
+++ b/src/AuthZyinProvider.test.tsx
@@ -95,7 +95,7 @@ describe('initializeAuthZyinContext/useAuthZyinContext', () => {
             const { result } = renderHook(useAuthZyinContext, { wrapper });
             expect(!result.error).toBeTruthy();
             expect(result.current).toBe(contextValue);
-            const resultRequirement = result.current.policies[0].requirements[0] as JsonPathConstantRequiremet;
+            const resultRequirement = result.current!.policies[0].requirements[0] as JsonPathConstantRequiremet;
             expect(resultRequirement.dataJPath).toBe(expectedDataPath);
             expect(resultRequirement.resourceJPath).toBe(expectedResourcePath);
             expect(resultRequirement.constValue).toBe(DummyRequirement.constValue);
@@ -120,10 +120,10 @@ describe('initializeAuthZyinContext/useAuthZyinContext', () => {
             await waitForNextUpdate();
 
             expect(!result.error).toBeTruthy();
-            expect(result.current.policies.length).toBe(1);
-            expect(result.current.policies[0].name).toBe(DummyPolicy.name);
-            expect(result.current.policies[0].requirements.length).toBe(DummyPolicy.requirements.length);
-            const resultRequirement = result.current.policies[0].requirements[0] as JsonPathConstantRequiremet;
+            expect(result.current!.policies.length).toBe(1);
+            expect(result.current!.policies[0].name).toBe(DummyPolicy.name);
+            expect(result.current!.policies[0].requirements.length).toBe(DummyPolicy.requirements.length);
+            const resultRequirement = result.current!.policies[0].requirements[0] as JsonPathConstantRequiremet;
             expect(resultRequirement.operator).toBe(DummyRequirement.operator);
             expect(resultRequirement.direction).toBe(DummyRequirement.direction);
             expect(resultRequirement.dataJPath).toBe(expectedDataPath);

--- a/src/Authorize.test.tsx
+++ b/src/Authorize.test.tsx
@@ -54,6 +54,12 @@ const resource = {
     }
 };
 
+const contextWithNoUserContext:AuthZyinContext = {
+    userContext: undefined!,
+    policies: [],
+    data: {}
+};
+
 const contextWithoutPolicies = {
     userContext: {
         roles: ['someOtherRole', 'rightRole']
@@ -76,12 +82,13 @@ const contextWithNoMatchingPolicy = {
 // Test authorize behavior based on different inputs
 describe('authorize function behaves correctly', () => {
     test.each([
+        [undefined,                     'candrink', false],
+        [contextWithNoUserContext,      'candrink', false],
         [context,                       'candrink', true],
-        [context,                       'canpay',   false],
         [context,                       'canpay',   false],
         [contextWithoutPolicies,        'candrink', false],
         [contextWithNoMatchingPolicy,   'candrink', false],
-    ])('authorize behavior (%#)', (context: AuthZyinContext, policy: string, expectedResult: boolean) =>
+    ])('authorize behavior (%#)', (context: AuthZyinContext | undefined, policy: string, expectedResult: boolean) =>
     {
         expect(authorizeFunc(context, policy, resource)).toBe(expectedResult);
     });

--- a/src/Authorize.tsx
+++ b/src/Authorize.tsx
@@ -10,23 +10,20 @@ import { useAuthZyinContext } from './AuthZyinProvider';
  * @param policy - the policy to authorize against
  * @param resource - resource, optional depending  on the policy and requirement
  */
-export const authorizeFunc = (context: AuthZyinContext<object>, policy: string, resource?: Resource) => {
-    if (!context || !context.policies) {
+export const authorizeFunc = (context: AuthZyinContext<object> | undefined, policy: string, resource?: Resource) => {
+    if (!context || !context.userContext || !context.policies) {
         // Incorrect context
         return false;
     }
 
     const policyObject = context.policies.filter((p) => p.name === policy)[0];
-
     if (!policyObject || !policyObject.requirements) {
         // Cannot find policy
         return false;
     }
 
-    const requirements = policyObject.requirements;
-    let result = true;
-    for (let i = 0; i < requirements.length; i++) {
-        result = evaluateRequirement(context, requirements[i], resource);
+    for (const requirement of policyObject.requirements) {
+        const result = evaluateRequirement(context, requirement, resource);
         if (!result) {
             return false; // requirement failed, no need to continue
         }
@@ -42,7 +39,7 @@ export const authorizeFunc = (context: AuthZyinContext<object>, policy: string, 
 export const useAuthorize = () => {
     const context = useAuthZyinContext<object>();
     return (policy: string, resource?: Resource) => {
-        return context && context.userContext && authorizeFunc(context, policy, resource);
+        return authorizeFunc(context, policy, resource);
     };
 };
 


### PR DESCRIPTION
Update authzyinprovider and react context typing to reflect the fact that it can be undefined.
This sacrifices some convenience but provides more "clarity" since it indeed can be undefined, specifically:

1. if initializeAuthZyinContext is not called, AuthZyinReactContext global will be undefined.
2. before context api call finishes (or when it fails), useAuthZyinContext can also return undefined.

To me clarity and transparency is more important than "convenience" and we should not hide those facts.